### PR TITLE
params: add option to specify param validation (refs #5)

### DIFF
--- a/docs/guide/parameters.rst
+++ b/docs/guide/parameters.rst
@@ -160,6 +160,52 @@ codes using pycountry module:
                     "".format(code=raw_value)
                 )
 
+Parameter validation
+~~~~~~~~~~~~~~~~~~~~
+
+Custom parameters are great for defining new data types that can be passed
+through HTTP query string or handling very specific cases like country codes,
+mime types, or even database filters. Still it may be sometimes an overkill
+to define new parameter class to do something as simple as ensure min/max
+bounds for numeric value or define as set of allowed choices.
+
+All of basic parameters available in graceful accept ``validators`` keyword
+argument that accepts a list of validation functions. These function will be
+always called upon parameter retrieval. This functionality allows you to
+quickly extend the semantic of your parameters without the need of subclassing.
+
+A validator is any callable that accepts single positional argument
+that will be a value returned from call to the ``value()`` handler of parameter
+class. If validation funtion fails it is supposed to return
+:class:`graceful.errors.ValidationError` that will be later translated to
+proper HTTP error response. Following is example of simple validation function
+which ensures that parameter string is palindrome:
+
+.. code-block:: python
+
+    from graceful.resources.base import BaseResource
+    from graceful.parameters import StrParam
+    from graceful.errors import ValidationError
+
+    def is_palindrome(value):
+        if value != value[::-1]:
+            raise ValidationError("{} is not a palindrome")
+
+
+    class FamousPhrases(Resource):
+        palindrome_query = StrParam(
+            "Palindrome text query", validators=[is_palindrome]
+        )
+
+
+Validators always work on deserialized values and this allows to easily reuse
+the same code across different types of parameters and also between fields
+(see: :ref:`field-validation`). Graceful takes advantage of this fact and already
+provides you with a small set of fully reusable validators that can be used to
+validate both your parameters and serialization fields. For more details see
+:any:`graceful.validators` module reference.
+
+
 
 Handling multiple occurences of parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/graceful/errors.py
+++ b/src/graceful/errors.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from falcon import HTTPBadRequest
+from falcon import HTTPBadRequest, HTTPInvalidParam
 
 
 class DeserializationError(ValueError):
@@ -59,4 +59,20 @@ class ValidationError(ValueError):
         return HTTPBadRequest(
             title="Validation failed",
             description=str(self)
+        )
+
+    def as_invalid_param(self, param_name):
+        """Translate this error to falcon's HTTP specific error exception.
+
+        Note:
+            Exceptions returned by this method should be used to inform about
+            param validation failures. In case of resource validation
+            failures the ``as_bad_request()`` method should be used.
+
+        Args:
+            param_name (str): HTTP query string parameter name
+
+        """
+        return HTTPInvalidParam(
+            str(self), param_name
         )

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -3,6 +3,7 @@ import decimal
 import base64
 
 import pytest
+from graceful.errors import ValidationError
 
 from graceful.parameters import (
     BaseParam,
@@ -13,6 +14,7 @@ from graceful.parameters import (
     DecimalParam,
     BoolParam,
 )
+from graceful.validators import min_validator, max_validator
 
 
 class TestParam(BaseParam):
@@ -72,6 +74,27 @@ def test_param_default_value():
 def test_string_param():
     param = StringParam(details="stringy stringy")
     assert param.value("foo") == "foo"
+
+
+@pytest.mark.parametrize('raw_value', ['10', '15', '20'])
+def test_int_param_validation_passes(raw_value):
+    param = IntParam(
+        details="min max test",
+        validators=[min_validator(10), max_validator(20)]
+    )
+
+    assert param.validated_value(raw_value) is int(raw_value)
+
+
+@pytest.mark.parametrize('raw_value', ['1', '9', '21'])
+def test_int_param_validation_fails(raw_value):
+    param = IntParam(
+        details="min max test",
+        validators=[min_validator(10), max_validator(20)]
+    )
+
+    with pytest.raises(ValidationError):
+        param.validated_value(raw_value)
 
 
 def _test_param(param, encoded, invalid, desired):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -264,7 +264,7 @@ def test_parameter_with_many_and_required():
 
 
 @pytest.mark.parametrize(
-    'query_string', ['number=10', 'number=10', 'number=10']
+    'query_string', ['number=10', 'number=15', 'number=20']
 )
 def test_parameter_with_validation_enabled_passes(query_string):
     class SomeResource(Resource):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -11,9 +11,10 @@ import pytest
 
 from graceful.errors import ValidationError
 from graceful.resources.generic import Resource
-from graceful.parameters import StringParam, BaseParam
+from graceful.parameters import StringParam, BaseParam, IntParam
 from graceful.serializers import BaseSerializer
 from graceful.fields import StringField
+from graceful.validators import min_validator, max_validator
 
 
 class TestResource(Resource):
@@ -252,14 +253,48 @@ def test_parameter_inheritance():
 
 def test_parameter_with_many_and_required():
     class SomeResource(Resource):
-        foo = StringParam(details="give me foo", required=True, many=True)
+        foo = IntParam(details="give me foo", required=True, many=True)
 
-    env = create_environ(query_string="foo=bar&foo=baz")
+    env = create_environ(query_string="foo=1&foo=2")
     resource = SomeResource()
     params = resource.require_params(Request(env))
 
     assert isinstance(params['foo'], Iterable)
-    assert set(params['foo']) == {'bar', 'baz'}
+    assert set(params['foo']) == {1, 2}
+
+
+@pytest.mark.parametrize(
+    'query_string', ['number=10', 'number=10', 'number=10']
+)
+def test_parameter_with_validation_enabled_passes(query_string):
+    class SomeResource(Resource):
+        number = IntParam(
+            details="number with min/max bounds",
+            validators=[min_validator(10), max_validator(20)]
+        )
+
+    env = create_environ(query_string=query_string)
+    resource = SomeResource()
+    params = resource.require_params(Request(env))
+
+    assert isinstance(params['number'], int)
+
+
+@pytest.mark.parametrize(
+    'query_string', ['number=5', 'number=100']
+)
+def test_parameter_with_validation_raises_bad_request(query_string):
+    class SomeResource(Resource):
+        number = IntParam(
+            details="number with min/max bounds",
+            validators=[min_validator(10), max_validator(20)]
+        )
+
+    env = create_environ(query_string=query_string)
+    resource = SomeResource()
+
+    with pytest.raises(errors.HTTPBadRequest):
+        resource.require_params(Request(env))
 
 
 def test_parameter_with_many_and_default(req):


### PR DESCRIPTION
This is solution for #5. 

Param validation is now handled by additional `validators` keyword argument to `BaseParam` class. This is consistent with API of field definitions so we favour the reuse of same validation functions. This means that all existing validato function factories available in `graceful.validators` module can be used with params too. The fact that params have different source than fields (query string instead of content-type serialized body) does not matter at all because in both cases we work on deserialized/internal values.

What is different is the way how validation is triggered. Field validation is mostly managed by field definition class but param validation is almost exclusively handled by `BaseResource.require_params()` method.