### PR TITLE
serializers: redesigned validation and star-like writable fields

### DIFF
--- a/docs/guide/serializers.rst
+++ b/docs/guide/serializers.rst
@@ -203,9 +203,6 @@ of resource serializer with custom object-level validation:
         mixed_with = StringField("what makes it tasty")
 
         def validate(self, object_dict, partial):
-            # note: always make sure to call super `validate_object()`
-            # to make sure that per-field validation is enabled.
-
             if partial and any([
                 'alcohol' in object_dict,
                 'mixed_with' in object_dict,
@@ -316,7 +313,6 @@ we want to support both writes and saves.
             }
 
         def validate(self, value):
-            print(value)
             if 'owner_age' not in value or not isinstance(value['owner_age'], int):
                 raise ValidationError("invalid owner age")
 

--- a/docs/guide/serializers.rst
+++ b/docs/guide/serializers.rst
@@ -265,28 +265,31 @@ manipulate multiple representation or internal object instance keys within the
 single field you need to create custom field class and override one or more
 of following methods:
 
-* ``read_instance(self, instance, key_or_attribute)``: read value from the
+* ``read_instance(self, instance, source)``: read value from the
   object instance before serialization. The return value will be later passed
-  as an argument to ``to_representation()`` method. The ``key_or_attribute``
-  argument is field's name or source (if ``source`` explicitly specified).
-  Base implementation defaults to dictionary key lookup or object attribute
-  lookup.
-* ``read_representation(self, representation, key_or_attribute)``: read value
-  from the object instance before deserialization. The return value will be
-  later passed as an argument to ``from_representation()`` method. The
-  ``key_or_attribute`` argument the field's name. Base implementation defaults
-  to dictionary key lookup or object attribute lookup.
-* ``update_instance(self, instance, key_or_attribute, value)``: update the
+  as an argument to ``to_representation()`` method. The ``source`` argument is
+  field's name or configured source name (if custom ``source`` is explicitly
+  specified for that field). Base implementation defaults to dictionary key
+  lookup or object attribute lookup.
+
+* ``update_instance(self, instance, source, value)``: update the
   content of object instance after deserialization. The ``value`` argument is
-  the return value of ``from_representation()`` method. The
-  ``key_or_attribute`` argument the field's name or source (if ``source``
-  explicitly specified). Base implementation defaults to dictionary key
+  the return value of ``from_representation()`` method. The ``source`` argument
+  is the field's name or source name (if custom ``source`` is explicitly
+  specified for that field). Base implementation defaults to dictionary key
   assignment or object attribute assignment.
-* ``update_representation(self, representation, key_or_attribute, value)``:
+
+* ``read_representation(self, representation, field_name)``: read value
+  from the representation before deserialization. The return value will be
+  later passed as an argument to ``from_representation()`` method. The
+  ``field_name`` argument is a field's name. Base implementation defaults
+  to dictionary key lookup or object attribute lookup.
+
+* ``update_representation(self, representation, field_name, value)``:
   update the content of representation instance after serialization.
   The ``value`` argument is the return value of ``to_representation()`` method.
-  The ``key_or_attribute`` argument the field's name. Base implementation
-  defaults to dictionary key assignment or object attribute assignment.
+  The ``field_name`` argument is a field's name. Base implementation
+  defaults to dictionary key assignment.
 
 To better explain how to use these methods let's assume that due to some
 storage backend constraints we cannot save nested dictionaries. All of fields
@@ -319,12 +322,12 @@ we want to support both writes and saves.
             if 'owner_name' not in value:
                 raise ValidationError("invalid owner name")
 
-        def update_instance(self, instance, attribute_or_key, value):
+        def update_instance(self, instance, source, value):
             # we assume that instance is always a dictionary so we can
             # use the .update() method
             instance.update(value)
 
-        def read_instance(self, instance, attribute_or_key):
+        def read_instance(self, instance, source):
             # .to_representation() method requires acces to whole object
             # dictionary so we have to return whole object.
             return instance

--- a/src/graceful/errors.py
+++ b/src/graceful/errors.py
@@ -34,7 +34,7 @@ class DeserializationError(ValueError):
                     "forbidden: {}".format(self.forbidden)
                     if self.forbidden else ""
                 ),
-                "invalid: {}:".format(self.invalid) if self.invalid else "",
+                "invalid: {}".format(self.invalid) if self.invalid else "",
                 (
                     "failed to parse: {}".format(self.failed)
                     if self.failed else ""

--- a/src/graceful/fields.py
+++ b/src/graceful/fields.py
@@ -194,65 +194,63 @@ class BaseField:
         for validator in self.validators:
             validator(value)
 
-    def update_instance(self, instance, attribute_or_key, value):
+    def update_instance(self, instance, source, value):
         """Update object instance after deserialization.
 
         Args:
             instance (object): dictionary or object after serialization.
-            attribute_or_key (str): field's name or source (if ``source``
-                explicitly specified).
+            source (str): field's name or source if ``source`` was
+                explicitly specified for that field.
             value (object): return value from ``from_representation`` method.
         """
         if isinstance(instance, MutableMapping):
-            instance[attribute_or_key] = value
+            instance[source] = value
         else:
-            setattr(instance, attribute_or_key, value)
+            setattr(instance, source, value)
 
-    def read_instance(self, instance, attribute_or_key):
+    def read_instance(self, instance, source):
         """Read value from the object instance before serialization.
 
         Args:
             instance (object): dictionary or object before serialization.
-            attribute_or_key (str): field's name or source (if ``source``
-                explicitly specified).
+            source (str): field's name or source if ``source`` was
+                explicitly specified for that field.
 
         Returns:
             The value that will be later passed as an argument to
             ``to_representation()`` method.
         """
         if isinstance(instance, Mapping):
-            return instance.get(attribute_or_key, None)
+            return instance.get(source, None)
 
-        return getattr(instance, attribute_or_key, None)
+        return getattr(instance, source, None)
 
-    def update_representation(self, representation, attribute_or_key, value):
+    def update_representation(self, representation, field_name, value):
         """Update representation after field serialization.
 
         Args:
-            instance (object): representation object.
+            representation (dict): representation dictionary.
             attribute_or_key (str): field's name.
             value (object): return value from ``to_representation`` method.
         """
-        if isinstance(representation, MutableMapping):
-            representation[attribute_or_key] = value
-        else:
-            setattr(representation, attribute_or_key, value)
+        # note: Unlike instances, representations can only be dictionaries
+        #       and their type cannot be overriden inside of serializer's class
+        representation[field_name] = value
 
-    def read_representation(self, representation, attribute_or_key):
+    def read_representation(self, representation, field_name):
         """Read value from the representation before deserialization.
 
         Args:
-            instance (object): dictionary or object before deserialization.
-            attribute_or_key (str): field's name.
+            representation (dict): representation dictionary.
+            field_name (str): field's name.
 
         Returns:
             The value that will be later passed as an argument to
             ``from_representation()`` method.
         """
-        if isinstance(representation, Mapping):
-            return representation.get(attribute_or_key, None)
-
-        return getattr(representation, attribute_or_key, None)
+        # note: Unlike instances, representations can only be dictionaries
+        #       and their type cannot be overriden inside of serializer's class
+        return representation.get(field_name, None)
 
 
 class RawField(BaseField):

--- a/src/graceful/resources/base.py
+++ b/src/graceful/resources/base.py
@@ -424,11 +424,11 @@ class BaseResource(metaclass=MetaResource):
 
         try:
             for representation in representations:
-                object_dict = self.serializer.from_representation(
-                    representation
+                object_dicts.append(
+                    self.serializer.from_representation(
+                        representation, partial
+                    )
                 )
-                self.serializer.validate(object_dict, partial)
-                object_dicts.append(object_dict)
 
         except DeserializationError as err:
             # when working on Resource we know that we can finally raise

--- a/src/graceful/serializers.py
+++ b/src/graceful/serializers.py
@@ -80,8 +80,9 @@ class BaseSerializer(metaclass=MetaSerializer):
 
     """
 
+    #: Allows to override instance object constructon with custom type
+    #: like defaultdict, SimpleNamespace or database model class.
     instance_factory = dict
-    representation_factory = dict
 
     @property
     def fields(self):
@@ -105,14 +106,18 @@ class BaseSerializer(metaclass=MetaSerializer):
             dict: representation dictionary
 
         """
-        representation = self.representation_factory()
+        # note: representations does not have their custom facotries like
+        #       instances because they as only used during content-type
+        #       serialization and deserialization and cannot be manipulated
+        #       inside of resource classes.
+        representation = {}
 
         for name, field in self.fields.items():
             if field.write_only:
                 continue
 
-            # note fields do not know their names in source representation
-            # but may know what attribute they target from source object
+            # note: fields do not know their names in source representation
+            #        but may know what attribute they target from instance
             attribute = field.read_instance(instance, field.source or name)
 
             if attribute is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,2 @@
 # those fixtures will be available for whole tests package
-from .fixtures import req, resp  # noqa
+from .fixtures import req, resp, instance_class  # noqa

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,7 +1,26 @@
+from types import SimpleNamespace as BaseSimpleNamespace
+from collections import defaultdict
+from functools import partial
+
 import pytest
 
 from falcon import Request, Response
 from falcon.testing import create_environ
+
+# compat: SimpleNamespace depends on of built-in sys module (the type of
+#         type of sys.implementation variable) and may be implementation
+#         dependent. For instance, in Python3.3 it does not have its own
+#         __eq__ method implementation so two equivalent namespaces do not
+#         compare as equal ones.
+if BaseSimpleNamespace() == BaseSimpleNamespace():
+    SimpleNamespace = BaseSimpleNamespace
+else:
+    class SimpleNamespace(BaseSimpleNamespace):
+        """Extended ``SimpleNamespace`` implementation for Python3.3."""
+
+        def __eq__(self, other):
+            """Check if two namesapces have equal content."""
+            return self.__dict__ == other.__dict__
 
 
 @pytest.fixture
@@ -15,3 +34,19 @@ def req():
 def resp():
     """Simple empty Response fixture."""
     return Response()
+
+
+@pytest.fixture(
+    params=[
+        dict,
+        SimpleNamespace,
+        # note: this is not a class per-se but acts like a one
+        partial(defaultdict, str)
+    ],
+)
+def instance_class(request):
+    """Instance class that may be used as a instance_factory attribute.
+
+    This fixture helps testing serializers.
+    """
+    return request.param

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -398,10 +398,10 @@ def test_whole_serializer_validation_as_hhtp_bad_request(req):
         one = StringField("one different than two")
         two = StringField("two different than one")
 
-        def validate(self, object_dict, partial=False):
-            super().validate(object_dict, partial)
+        def validate(self, instance, partial=False):
+            super().validate(instance, partial)
             # possible use case: kind of uniqueness relationship
-            if object_dict['one'] == object_dict['two']:
+            if instance['one'] == instance['two']:
                 raise ValidationError("one must be different than two")
 
     class TestResource(Resource):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -22,11 +22,13 @@ class ExampleField(BaseField):
         return value
 
 
-def test_simple_serializer_definition():
+def test_simple_serializer_definition(instance_class):
     """
     Test if serializers can be defined in declarative way
     """
     class TestSimpleSerializer(BaseSerializer):
+        instance_factory = instance_class
+
         foo = ExampleField(
             details="first field for testing"
         )
@@ -42,11 +44,12 @@ def test_simple_serializer_definition():
     assert 'foo' in serializer.fields
 
 
-def test_empty_serializer_definition():
+def test_empty_serializer_definition(instance_class):
     """
     Make sure even empty serializer has the same interface
     """
     class TestEmptySerializer(BaseSerializer):
+        instance_factory = instance_class
         pass
 
     serializer = TestEmptySerializer()
@@ -54,8 +57,9 @@ def test_empty_serializer_definition():
     assert len(serializer.fields) == 0
 
 
-def test_serializer_inheritance():
+def test_serializer_inheritance(instance_class):
     class TestParentSerializer(BaseSerializer):
+        instance_factory = instance_class
         foo = ExampleField(
             details="first field for testing"
         )
@@ -64,6 +68,7 @@ def test_serializer_inheritance():
         )
 
     class TestDerivedSerializer(TestParentSerializer):
+        instance_factory = instance_class
         baz = ExampleField(
             details="this is additional field added as an extension"
         )
@@ -78,7 +83,7 @@ def test_serializer_inheritance():
     assert 'baz' in serializer.fields
 
 
-def test_serializer_field_overriding():
+def test_serializer_field_overriding(instance_class):
     """
     Test serializer fields can be overriden
     """
@@ -86,10 +91,14 @@ def test_serializer_field_overriding():
     parent_label = "parent"
 
     class TestParentSerializer(BaseSerializer):
+        instance_factory = instance_class
+
         foo = ExampleField(label=parent_label, details="parent foo field")
         bar = ExampleField(label=parent_label, details="parent bar field")
 
     class TestOverridingSerializer(TestParentSerializer):
+        instance_factory = instance_class
+
         foo = ExampleField(label=override_label, details='overriden foo field')
 
     serializer = TestOverridingSerializer()
@@ -102,36 +111,39 @@ def test_serializer_field_overriding():
     assert serializer.fields['bar'].label == parent_label
 
 
-def test_serialiser_simple_representation():
+def test_serializer_simple_representation(instance_class):
     class SomeConcreteSerializer(BaseSerializer):
+        instance_factory = instance_class
+
         name = ExampleField(details="name of instance object")
         address = ExampleField(details="instance address")
 
-    object_instance = {
-        "name": "John",
-        "address": "US",
+    instance = instance_class(
+        name="John",
+        address="US",
         # note: gender is not included in serializer
         #   fields so it will be dropped
-        "gender": "male",
-    }
+        gender="male",
+    )
 
     serializer = SomeConcreteSerializer()
 
     # test creating representation
-    representation = serializer.to_representation(object_instance)
+    representation = serializer.to_representation(instance)
     assert representation == {"name": "John", "address": "US"}
 
     # test recreating instance
     recreated = serializer.from_representation(representation)
-    assert recreated == {"name": "John", "address": "US"}
+    assert recreated == instance_class(name="John", address="US")
 
 
-def test_serialiser_sources_representation():
+def test_serializer_sources_representation(instance_class):
     """
     Test representing objects with sources of fields different that their names
     """
-
     class SomeConcreteSerializer(BaseSerializer):
+        instance_factory = instance_class
+
         name = ExampleField(
             details="name of instance object (taken from _name)",
             source="_name",
@@ -141,23 +153,23 @@ def test_serialiser_sources_representation():
             source="_address"
         )
 
-    object_instance = {
-        "_name": "John",
-        "_address": "US",
+    instance = instance_class(
+        _name="John",
+        _address="US",
         # note: gender is not included in serializer
         #   fields so it will be dropped
-        "gender": "male",
-    }
+        gender="male",
+    )
 
     serializer = SomeConcreteSerializer()
 
     # test creating representation
-    representation = serializer.to_representation(object_instance)
+    representation = serializer.to_representation(instance)
     assert representation == {"name": "John", "address": "US"}
 
     # test recreating instance
     recreated = serializer.from_representation(representation)
-    assert recreated == {"_name": "John", "_address": "US"}
+    assert recreated == instance_class(_name="John", _address="US")
 
 
 def test_serializer_read_only_write_only_serialization():
@@ -188,10 +200,12 @@ def test_serializer_read_only_write_only_deserialization():
         serializer.from_representation({'readonly': 'x'})
 
 
-def test_serializer_describe():
+def test_serializer_describe(instance_class):
     """ Test that serializers are self-describing
     """
     class ExampleSerializer(BaseSerializer):
+        instance_factory = instance_class
+
         foo = ExampleField(label='foo', details='foo foo')
         bar = ExampleField(label='bar', details='bar bar')
 
@@ -209,34 +223,44 @@ def test_serializer_describe():
     ])
 
 
-def test_serialiser_with_field_many():
-    class UpperField(BaseField):
+def test_serializer_with_field_many(instance_class):
+    class CaseSwitchField(BaseField):
         def to_representation(self, value):
             return value.upper()
 
         def from_representation(self, data):
-            return data.upper()
+            return data.lower()
 
     class ExampleSerializer(BaseSerializer):
-        up = UpperField(details='multiple values field', many=True)
+        instance_factory = instance_class
+
+        case_switch = CaseSwitchField(
+            details='multiple values field', many=True
+        )
 
     serializer = ExampleSerializer()
-    obj = {'up': ["aa", "bb", "cc"]}
-    desired = {'up': ["AA", "BB", "CC"]}
 
-    assert serializer.to_representation(obj) == desired
-    assert serializer.from_representation(obj) == desired
+    # note: it can be any object type, not only a dictionary
+    instance = instance_class(case_switch=["aa", "bb", "cc"])
+    desired = {'case_switch': ["AA", "BB", "CC"]}
+
+    assert serializer.to_representation(instance) == desired
+    assert serializer.from_representation(desired) == instance
 
     with pytest.raises(ValueError):
-        serializer.from_representation({"up": "definitely not a sequence"})
+        serializer.from_representation(
+            {"case_switch": "definitely not a sequence"}
+        )
 
 
-def test_serializer_many_validation():
+def test_serializer_many_validation(instance_class):
     def is_upper(value):
         if value.upper() != value:
             raise ValueError("should be upper")
 
     class ExampleSerializer(BaseSerializer):
+        instance_factory = instance_class
+
         up = StringField(
             details='multiple values field',
             many=True,


### PR DESCRIPTION
This changes are not backwards compatible so will require updating major version.

* remove `source="*"` handling
* move instance/representation manipulation responsibility
  to field objects to support nested objects and multiple key
  access pattern
* update docs
* fix #44 (writable star-like fields)
* fix #43 (broken resource manipulation on star-like fields)
* fix #42 (wrong field descriptions on validation errors)
* redesign resource/field validation process