### PR TITLE
Noticed allow_null has a bug when submitting a value for a nullable field within a post request 

### DIFF
--- a/src/graceful/serializers.py
+++ b/src/graceful/serializers.py
@@ -196,8 +196,10 @@ class BaseSerializer(metaclass=MetaSerializer):
                             for single_value in value
                         ]
                 else:
-                    object_dict[source] = field.from_representation(
-                        value) if not field.allow_null else None
+                    if not field.allow_null:
+                        object_dict[source] = field.from_representation(value)
+                    else:
+                        object_dict[source] = value
 
             except ValueError as err:
                 failed[name] = str(err)


### PR DESCRIPTION
Hi, 

While we were using graceful in a workshop, participants had discovered a bug with `allow_null` implementation. The bug was when a value send for a nullable field in the request, its value becomes always `None`.

The next day I have prepared this version of code, and asked them to install from my fork via `pip`'s `git+"github_repo"` feature. While this version works on my computer well, they had still the same issue (They were working on the Ubuntu 16.04, probably in a virtual machine, and I am using MacOSX Sierra 10.12.2). 

I did not very well examined the situation and did not make trials on different OSs, but what do you think about preparing docker containers to run tests on different OSs? Or, maybe you have any other suggestions? 

Thanks in advance. 